### PR TITLE
Convert hash to a Javascript object so it works with classnames 2.3.0

### DIFF
--- a/addon/helpers/class-names.js
+++ b/addon/helpers/class-names.js
@@ -1,10 +1,17 @@
 import { helper } from '@ember/component/helper';
 import classnames from 'classnames';
 
+/**
+ * Params and hash are actually Proxies from glimmer:
+ *
+ * - params is a PositionalArgsProxy: https://github.com/glimmerjs/glimmer-vm/blob/09a959a14c3da4875f460ddfe545a80a7af93b04/packages/%40glimmer/manager/lib/util/args-proxy.ts#L102-L133
+ * - hash is a NamedArgsProxy: https://github.com/glimmerjs/glimmer-vm/blob/09a959a14c3da4875f460ddfe545a80a7af93b04/packages/%40glimmer/manager/lib/util/args-proxy.ts#L61-L100
+ *
+ * and hence have slightly different behaviours than arrays and conventional Javascript objects
+ */
 export default helper(function classNames(params, hash) {
-  const hashAsObject = {};
-  for (const key in hash) {
-    hashAsObject[key] = hash[key];
-  }
-  return classnames(...params, hashAsObject);
+  // convert hash to a plain Javascript object
+  const entries = Object.entries(hash);
+  hash = Object.fromEntries(entries);
+  return classnames(...params, hash);
 });

--- a/addon/helpers/class-names.js
+++ b/addon/helpers/class-names.js
@@ -2,5 +2,9 @@ import { helper } from '@ember/component/helper';
 import classnames from 'classnames';
 
 export default helper(function classNames(params, hash) {
-  return classnames(...params, hash);
+  const hashAsObject = {};
+  for (const key in hash) {
+    hashAsObject[key] = hash[key];
+  }
+  return classnames(...params, hashAsObject);
 });

--- a/addon/helpers/class-names.js
+++ b/addon/helpers/class-names.js
@@ -1,17 +1,23 @@
 import { helper } from '@ember/component/helper';
 import classnames from 'classnames';
 
-/**
- * Params and hash are actually Proxies from glimmer:
- *
- * - params is a PositionalArgsProxy: https://github.com/glimmerjs/glimmer-vm/blob/09a959a14c3da4875f460ddfe545a80a7af93b04/packages/%40glimmer/manager/lib/util/args-proxy.ts#L102-L133
- * - hash is a NamedArgsProxy: https://github.com/glimmerjs/glimmer-vm/blob/09a959a14c3da4875f460ddfe545a80a7af93b04/packages/%40glimmer/manager/lib/util/args-proxy.ts#L61-L100
- *
- * and hence have slightly different behaviours than arrays and conventional Javascript objects
- */
-export default helper(function classNames(params, hash) {
-  // convert hash to a plain Javascript object
-  const entries = Object.entries(hash);
-  hash = Object.fromEntries(entries);
-  return classnames(...params, hash);
-});
+export default helper(
+  /**
+   * Wrapper for classnames, which creates a string of classes that concatenates all positional arguments + named arguments with truthy values
+   *
+   * While the arguments generally behave like Javascript objects and arrays, there are some differences - eg. the lack of a `toString` method. For more information, see:
+   * - PositionalArgsProxy: https://github.com/glimmerjs/glimmer-vm/blob/09a959a14c3da4875f460ddfe545a80a7af93b04/packages/%40glimmer/manager/lib/util/args-proxy.ts#L102-L133
+   * - NamedArgsProxy: https://github.com/glimmerjs/glimmer-vm/blob/09a959a14c3da4875f460ddfe545a80a7af93b04/packages/%40glimmer/manager/lib/util/args-proxy.ts#L61-L100
+   *
+   * @param {PositionalArgsProxy} params Positional arguments passed to the helper as a proxy that behaves like an array
+   * @param {NamedArgsProxy} hash Named arguments passed to the helper as a proxy that behaves like a Javascript object
+   *
+   * @returns A string of classes
+   */
+  function classNames(params, hash) {
+    // Change NamedArgsProxy -> Javascript object for compatibility with classnames@2.3.x
+    const entries = Object.entries(hash);
+    hash = Object.fromEntries(entries);
+    return classnames(...params, hash);
+  }
+);


### PR DESCRIPTION
This lets the addon work for classnames 2.3.0 (fixes #6).